### PR TITLE
Build for Devuan Chimaera

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+CFLAGS += -Wno-error=deprecated-declarations
+
 all: libsystemuiplugin_tklock.so
 
 clean:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,8 @@
+osso-systemui-tklock (0.5.2) unstable; urgency=low
+  * Changed cflags for compatibility with GCC 10+
+
+ -- Blagovest Petrov <blagovest@petrovs.info> Sat, 26 Nov 2022 02:23:32 +0300
+
 osso-systemui-tklock (0.5.1) unstable; urgency=low
 
   * Do not override log ident set by systemui


### PR DESCRIPTION
Added cflag for ignoring GTK deprecation warnings. It was failing with those errors:

```
...
/usr/include/gtk-2.0/gtk/gtktooltips.h:73:3: warning: 'GTimeVal' is deprecated: Use 'GDateTime' instead [-Wdeprecated-declarations]
   73 |   GTimeVal last_popdown;
      |   ^~~~~~~~
In file included from /usr/include/glib-2.0/glib/galloca.h:32,
                 from /usr/include/glib-2.0/glib.h:30,
                 from /usr/include/glib-2.0/gobject/gbinding.h:28,
                 from /usr/include/glib-2.0/glib-object.h:22,
                 from /usr/include/glib-2.0/gio/gioenums.h:28,
                 from /usr/include/glib-2.0/gio/giotypes.h:28,
                 from /usr/include/glib-2.0/gio/gio.h:26,
                 from /usr/include/gtk-2.0/gdk/gdkapplaunchcontext.h:30,
                 from /usr/include/gtk-2.0/gdk/gdk.h:32,
                 from /usr/include/gtk-2.0/gdk/gdkprivate.h:30,
                 from /usr/include/gtk-2.0/gdk/gdkx.h:30,
                 from osso-systemui-tklock.c:25:
...
```